### PR TITLE
News-Brazil jumps to No. 2 in worldwide coronavirus cases, behind US (October 27,2020)

### DIFF
--- a/Brazil jumps to No. 2 in worldwide coronavirus cases, behind the US
+++ b/Brazil jumps to No. 2 in worldwide coronavirus cases, behind the US
@@ -1,0 +1,1 @@
+<iframe src="https://ourworldindata.org/coronavirus-data-explorer?zoomToSelection=true&country=~BRA&region=World&casesMetric=true&interval=daily&hideControls=true&smoothing=0&pickerMetric=location&pickerSort=asc" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>


### PR DESCRIPTION
Hey this Praduman Covid-19 tracker.